### PR TITLE
Fixed broken get channels

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
 	"id": "com.slack",
 	"brandColor": "#E01563",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"sdk": 2,
 	"name": {
 		"en": "Slack"
@@ -14,6 +14,14 @@
 	"author": {
 		"name": "Athom B.V.",
 		"email": "support@athom.com"
+	},
+	"contributors": {
+		"developers": [
+		 	{
+				"name": "Even Ambjørnrud",
+				"email": "even@ambjornrud.no"
+			}
+		]
 	},
 	"images": {
 		"large": "./assets/images/large.jpg",

--- a/lib/Slack.js
+++ b/lib/Slack.js
@@ -66,7 +66,7 @@ class Slack {
 		Public Api methods
 	*/	
 	getChannels() {
-		return this._get('/channels.list')
+		return this._get('/conversations.list')
 			.then(result => result.channels);
 	}
 	


### PR DESCRIPTION
Fixed not beeing able to get channels due to use of long time announced deprecation and now retired api-method (since February 24th, 2021).

Deprecation-details:
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api